### PR TITLE
Add long_description_content_type markdown

### DIFF
--- a/{{cookiecutter.app_name}}/setup.py
+++ b/{{cookiecutter.app_name}}/setup.py
@@ -22,6 +22,7 @@ setup(
     version=__version__,
     description='{{cookiecutter.project_short_description}}',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     url='https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.app_name}}',
     download_url='https://github.com/{{cookiecutter.github_username}}/{{cookiecutter.app_name}}/tarball/' + __version__,
     license='BSD',


### PR DESCRIPTION
Need to add [long_description_content_type](https://packaging.python.org/specifications/core-metadata/#description-content-type) argument in `setup.py` to make sure that the markdown is styled correctly in PyPI