### PR TITLE
Fix broken uv PATH and outdated action pins in generated GitHub Actions workflows

### DIFF
--- a/{{cookiecutter.app_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/docs.yml
@@ -8,24 +8,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone
-        uses: actions/checkout@v1
-      
+        uses: actions/checkout@v4
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      
+
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v5
       
       - name: Install Dependencies
         run: |
           uv pip install --system -e ".[dev]"
       
       - name: Build Docs
-        uses: ammaraskar/sphinx-action@master
+        uses: ammaraskar/sphinx-action@8.2.3
         with:
           docs-folder: "./docs/"
       

--- a/{{cookiecutter.app_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
       id-token: write
     steps:
       - name: Clone
-        uses: actions/checkout@v3
-      
+        uses: actions/checkout@v4
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
       

--- a/{{cookiecutter.app_name}}/.github/workflows/test-docs.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/test-docs.yml
@@ -7,23 +7,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v1
-    
+      uses: actions/checkout@v4
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    
+
     - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      uses: astral-sh/setup-uv@v5
     
     - name: Install Dependencies
       run: |
         uv pip install --system -e ".[dev]"
     
     - name: Build Docs
-      uses: ammaraskar/sphinx-action@master
+      uses: ammaraskar/sphinx-action@8.2.3
       with:
         docs-folder: "docs/"

--- a/{{cookiecutter.app_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/test.yml
@@ -15,17 +15,15 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
-      
+      uses: actions/checkout@v4
+
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    
+
     - name: Install uv
-      run: |
-        curl -LsSf https://astral.sh/uv/install.sh | sh
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+      uses: astral-sh/setup-uv@v5
     
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Closes #13

## Summary
The generated CI workflows installed `uv` by hand and then added `$HOME/.cargo/bin` to `PATH`. The current uv standalone installer resolves its install dir to `$HOME/.local/bin` (via XDG), not `~/.cargo/bin`, so the subsequent `uv pip install` steps could fail with `uv: command not found`. This replaces the fragile manual install with the official action and refreshes stale action pins.

## What changed (`.github/workflows/` only)
- **`test.yml`, `docs.yml`, `test-docs.yml`** — replaced the manual `curl … | sh` + `echo "$HOME/.cargo/bin" >> $GITHUB_PATH` install with `astral-sh/setup-uv@v5`, which guarantees `uv` on `PATH`.
- **All four workflows** — bumped `actions/checkout` to `@v4` (was `@v1` in docs/test-docs, `@v3` in test/publish) and `actions/setup-python` to `@v5` (was `@v4`).
- **`docs.yml`, `test-docs.yml`** — pinned `ammaraskar/sphinx-action` to `@8.2.3` instead of the moving `@master` ref.

No change to what is built/tested/published — only how the toolchain is set up. The dependency-install steps still run `uv pip install --system -e ".[dev]"` unchanged.

## Verification
- `grep -rn cargo .github/workflows/` → no matches (no workflow references `$HOME/.cargo/bin`).
- Confirmed `actions/checkout@v4` and `actions/setup-python@v5` across all four workflows.
- Verified `astral-sh/setup-uv@v5` (existing maintained tag) and `ammaraskar/sphinx-action@8.2.3` (latest release tag) exist.
- Validated all four workflow YAML files parse with `yaml.safe_load`.