### PR TITLE
Fix generated scaffold so it passes its own make lint / CI out of the box

### DIFF
--- a/{{cookiecutter.app_name}}/pyproject.toml
+++ b/{{cookiecutter.app_name}}/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
 target-version = "py38"
 line-length = 120
 fix = true
+extend-exclude = ["docs"]
 select = [
     "E",   # pycodestyle errors
     "W",   # pycodestyle warnings

--- a/{{cookiecutter.app_name}}/tests/__init__.py
+++ b/{{cookiecutter.app_name}}/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite for {{cookiecutter.app_name}}."""

--- a/{{cookiecutter.app_name}}/tests/test_sample.py
+++ b/{{cookiecutter.app_name}}/tests/test_sample.py
@@ -1,4 +1,6 @@
-# Sample Test passing with pytess
+"""Sample test module."""
+
 
 def test_pass():
-        assert True
+    """Sample test that always passes."""
+    assert True

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/__init__.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level package for {{cookiecutter.project_name}}."""


### PR DESCRIPTION
Closes #12

## What changed
A project generated from this template failed `make lint` (and the `Test Suite and Linting` CI job) on the very first push, before any user code, because the scaffold did not satisfy its own enabled ruff `D` (pydocstyle) rules and was not ruff-formatted.

Fixes, confined to scaffold contents + ruff config:

- **`{{cookiecutter.app_name}}/__init__.py`** — added a package docstring (`"""Top-level package for {{cookiecutter.project_name}}."""`), fixing `D104`. Uses `project_name` with a literal trailing period so it stays valid regardless of the user's description punctuation (`D400`/`D415`).
- **`tests/__init__.py`** — added a package docstring, fixing `D104`.
- **`tests/test_sample.py`** — added module + function docstrings (`D100`/`D103`) and reformatted the 8-space body to 4-space indentation so `ruff format --check` passes.
- **`pyproject.toml`** — added `extend-exclude = ["docs"]` under `[tool.ruff]`. The autogenerated Sphinx `docs/source/conf.py` also failed both `ruff check` (`D100`) and `ruff format --check` (extensive boilerplate reformat). Excluding the autogenerated docs dir is the conventional fix and keeps `ruff check .` / `ruff format --check .` (which scan the whole tree) green without churning generated Sphinx boilerplate.

No runtime behavior of generated packages changes — only scaffold contents and ruff config.

## Verification
Rendered the template with cookiecutter defaults (`app_name=mypippkg`) and ran the same commands `make lint` invokes:

- `ruff check .` → `All checks passed!` (exit 0)
- `ruff format --check .` → `3 files already formatted` (exit 0)
- `mypy mypippkg` → `Success: no issues found in 1 source file` (exit 0)

(Note: full `cookiecutter .` generation currently aborts on an unrelated, pre-existing bug — `docs.yml` contains a bare `${{ secrets.GITHUB_TOKEN }}` that Jinja tries to render — so the scaffold files were rendered directly for verification. That generation bug is out of scope for this issue.)
