### PR TITLE
Escape GitHub expressions during template rendering

### DIFF
--- a/.github/workflows/test-template.yml
+++ b/.github/workflows/test-template.yml
@@ -1,0 +1,18 @@
+name: Test template
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run template tests
+        run: uv run --with cookiecutter python -m unittest discover -s tests

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,27 @@
+"""Regression tests for rendering the Cookiecutter template."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from cookiecutter.main import cookiecutter
+
+
+class TemplateRenderTest(unittest.TestCase):
+    """Verify the template can be rendered with its default inputs."""
+
+    def test_default_render_preserves_github_token_expression(self) -> None:
+        """Render defaults and retain the GitHub Actions secret expression."""
+        template_dir = Path(__file__).resolve().parents[1]
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            project_dir = Path(
+                cookiecutter(str(template_dir), no_input=True, output_dir=output_dir)
+            )
+            docs_workflow = project_dir / ".github" / "workflows" / "docs.yml"
+
+            self.assertIn("${{ secrets.GITHUB_TOKEN }}", docs_workflow.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/{{cookiecutter.app_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/docs.yml
@@ -30,5 +30,5 @@ jobs:
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: {% raw %}${{ secrets.GITHUB_TOKEN }}{% endraw %}
           publish_dir: "./docs/build/html/"


### PR DESCRIPTION
Closes #16

## Summary

- wrap the GitHub Actions token expression in a Jinja raw block so Cookiecutter emits it literally
- add a repository-level regression test that renders the template with default inputs through Cookiecutter
- run the generator regression test in GitHub Actions using uv

## Verification

- `uv run --with cookiecutter python -m unittest discover -s tests -v` — passed with Cookiecutter 2.7.1
- `uv run --with cookiecutter cookiecutter . --no-input --output-dir <temporary-directory>` — completed and the rendered docs workflow retained `${{ secrets.GITHUB_TOKEN }}`
- generated a default scaffold, ran `make install-dev`, `make test`, and `make lint` in its uv virtual environment — all passed
- `uvx ruff check tests` — passed
- `uvx ruff format --check tests` — passed