### PR TITLE
Align generated projects with supported Python versions

### DIFF
--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,6 +1,8 @@
 """Regression tests for rendering the Cookiecutter template."""
 
+import configparser
 import tempfile
+import tomllib
 import unittest
 from pathlib import Path
 
@@ -21,6 +23,42 @@ class TemplateRenderTest(unittest.TestCase):
             docs_workflow = project_dir / ".github" / "workflows" / "docs.yml"
 
             self.assertIn("${{ secrets.GITHUB_TOKEN }}", docs_workflow.read_text())
+
+    def test_default_render_has_consistent_python_support(self) -> None:
+        """Keep package metadata, tools, tox, and CI on the supported range."""
+        template_dir = Path(__file__).resolve().parents[1]
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            project_dir = Path(
+                cookiecutter(str(template_dir), no_input=True, output_dir=output_dir)
+            )
+            config = tomllib.loads((project_dir / "pyproject.toml").read_text())
+            classifiers = config["project"]["classifiers"]
+            python_classifiers = {
+                classifier.removeprefix("Programming Language :: Python :: ")
+                for classifier in classifiers
+                if classifier.startswith("Programming Language :: Python :: 3.")
+            }
+            tox_config = config["tool"]["tox"]["legacy_tox_ini"]
+            workflow = (project_dir / ".github" / "workflows" / "test.yml").read_text()
+            tox = configparser.ConfigParser()
+            tox.read_string(tox_config)
+            tox_environments = tox["tox"]["env_list"].split()
+
+            self.assertEqual(config["project"]["requires-python"], ">=3.12")
+            self.assertEqual(python_classifiers, {"3.12", "3.13", "3.14"})
+            self.assertEqual(config["tool"]["ruff"]["target-version"], "py312")
+            self.assertEqual(config["tool"]["mypy"]["python_version"], "3.12")
+            self.assertEqual(
+                tox_environments, ["py312", "py313", "py314", "lint", "type"]
+            )
+            self.assertIn("python-version: ['3.12', '3.14']", workflow)
+            self.assertEqual(workflow.count("make test"), 1)
+            self.assertEqual(workflow.count("make lint"), 1)
+            for workflow_path in (project_dir / ".github" / "workflows").glob("*.yml"):
+                workflow_text = workflow_path.read_text()
+                for unsupported in ("'3.8'", "'3.9'", "'3.10'", "'3.11'"):
+                    self.assertNotIn(unsupported, workflow_text)
 
 
 if __name__ == "__main__":

--- a/{{cookiecutter.app_name}}/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/{{cookiecutter.app_name}}/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -57,11 +57,9 @@ body:
       label: Python Version
       description: What version of Python are you using?
       options:
+        - "3.14"
+        - "3.13"
         - "3.12"
-        - "3.11"
-        - "3.10"
-        - "3.9"
-        - "3.8"
     validations:
       required: true
 
@@ -79,4 +77,4 @@ body:
       description: By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
-          required: true 
+          required: true

--- a/{{cookiecutter.app_name}}/.github/workflows/docs.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.14'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5

--- a/{{cookiecutter.app_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.14'
       
       - name: Install uv
         run: |

--- a/{{cookiecutter.app_name}}/.github/workflows/test-docs.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/test-docs.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: '3.14'
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/{{cookiecutter.app_name}}/.github/workflows/test.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# This workflow installs dependencies, tests supported Python versions, and runs quality checks.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: "Test Suite and Linting"
@@ -12,7 +12,10 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    strategy:
+      matrix:
+        python-version: ['3.12', '3.14']
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -20,7 +23,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: {% raw %}${{ matrix.python-version }}{% endraw %}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -32,7 +35,26 @@ jobs:
     - name: Run tests
       run: |
         make test
-    
+
+  quality:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.14'
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install dependencies
+      run: |
+        uv pip install --system -e ".[dev]"
+
     - name: Run linting
       run: |
         make lint

--- a/{{cookiecutter.app_name}}/pyproject.toml
+++ b/{{cookiecutter.app_name}}/pyproject.toml
@@ -16,13 +16,11 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 dependencies = []
 
 [project.optional-dependencies]
@@ -39,7 +37,7 @@ dev = [
 ]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py312"
 line-length = 120
 fix = true
 extend-exclude = ["docs"]
@@ -65,7 +63,7 @@ line-ending = "auto"
 known-first-party = ["{{cookiecutter.app_name}}"]
 
 [tool.mypy]
-python_version = "3.8"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -80,11 +78,9 @@ legacy_tox_ini = """
 [tox]
 min_version = 4.0
 env_list = 
-    py38
-    py39
-    py310
-    py311
     py312
+    py313
+    py314
     lint
     type
 isolated_build = True
@@ -102,4 +98,4 @@ commands =
 [testenv:type]
 deps = .[dev]
 commands = mypy {{cookiecutter.app_name}}
-""" 
+"""


### PR DESCRIPTION
Closes #19

## Summary

- raise the generated package minimum to Python 3.12 and align classifiers, Ruff, mypy, and tox through Python 3.14
- test the minimum and newest supported versions in a CI matrix while running lint and type checks once
- align supporting workflows and issue-report choices with the supported range
- add a render regression test that protects the synchronized version contract

## Verification

- `uv run --with cookiecutter python -m unittest discover -s tests` — 2 tests passed
- freshly rendered defaults: `uv run --python 3.12 --extra dev python -m pytest` — 1 test passed
- freshly rendered defaults: `uv run --python 3.14 --extra dev python -m pytest` — 1 test passed (local uv provisioned CPython 3.14.0rc1)
- freshly rendered defaults: `uv run --python 3.14 --extra dev make lint` — Ruff check/format and mypy passed
- freshly rendered defaults: `uv run --python 3.14 --extra dev make docs` — Sphinx build passed with 3 pre-existing warnings
- `git diff --check` — passed