### PR TITLE
Publish a wheel alongside the source distribution

### DIFF
--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -60,6 +60,24 @@ class TemplateRenderTest(unittest.TestCase):
                 for unsupported in ("'3.8'", "'3.9'", "'3.10'", "'3.11'"):
                     self.assertNotIn(unsupported, workflow_text)
 
+    def test_default_render_builds_and_verifies_release_artifacts(self) -> None:
+        """Build both distributions and verify them before publication."""
+        template_dir = Path(__file__).resolve().parents[1]
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            project_dir = Path(
+                cookiecutter(str(template_dir), no_input=True, output_dir=output_dir)
+            )
+            workflow = (
+                project_dir / ".github" / "workflows" / "publish.yml"
+            ).read_text()
+
+            self.assertIn("python -m build\n", workflow)
+            self.assertNotIn("python -m build --sdist", workflow)
+            self.assertIn("twine check dist/*", workflow)
+            self.assertIn("dist/*.whl", workflow)
+            self.assertIn('-c "import mypippkg"', workflow)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/{{cookiecutter.app_name}}/.github/workflows/publish.yml
+++ b/{{cookiecutter.app_name}}/.github/workflows/publish.yml
@@ -34,7 +34,7 @@ jobs:
           uv pip install -e ".[dev]"
           uv pip install build
       
-      - name: Build source distribution
+      - name: Build distributions
         run: |
           # Clean the build directories first
           rm -rf build/
@@ -46,8 +46,18 @@ jobs:
           find . -path ./.venv -prune -o -name '*.egg' -type f -exec rm -f {} \; 2>/dev/null || true
           find . -path ./.venv -prune -o -name '__pycache__' -type d -exec rm -rf {} \; 2>/dev/null || true
           
-          # Build only the source distribution
-          python -m build --sdist
+          # Build the source and wheel distributions
+          python -m build
+
+      - name: Check distributions
+        run: twine check dist/*
+
+      - name: Verify wheel
+        run: |
+          uv venv .wheel-venv
+          uv pip install --python .wheel-venv/bin/python dist/*.whl
+          cd "$(mktemp -d)"
+          "$GITHUB_WORKSPACE/.wheel-venv/bin/python" -c "import {{cookiecutter.app_name}}"
       
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #20

## Summary

- build both wheel and source distributions for releases
- validate all generated artifacts with Twine before publishing
- install the wheel into a clean environment and import the package outside the checkout
- add a render regression test for the release workflow

The existing PyPI publish action and Trusted Publishing permission are unchanged.

## Verification

- uv run --with cookiecutter python -m unittest discover -s tests — 3 tests passed
- rendered the default project, ran python -m build, and confirmed exactly one wheel and one source distribution
- ran twine check against both rendered artifacts — both passed
- installed the rendered wheel into a fresh uv virtual environment and imported mypippkg from outside the generated checkout — passed
- git diff --check — passed