### PR TITLE
Validate app_name before generating the package

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,26 @@
+"""Validate Cookiecutter answers before the project is generated."""
+
+import keyword
+import sys
+
+APP_NAME = {{ cookiecutter.app_name | jsonify }}
+
+
+def main() -> None:
+    """Reject app_name values that cannot be used as a Python package."""
+    if (
+        not APP_NAME.isascii()
+        or not APP_NAME.isidentifier()
+        or keyword.iskeyword(APP_NAME)
+    ):
+        sys.stderr.write(
+            f"ERROR: app_name {APP_NAME!r} is not a valid Python package name.\n"
+            "It is used as both the import package and the distribution name, so "
+            "it must be a valid Python identifier: ASCII letters, digits and "
+            "underscores only, not starting with a digit, and not a Python "
+            "keyword. For example: 'mypippkg' or 'my_package'.\n"
+        )
+        raise SystemExit(1)
+
+
+main()

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,11 +1,15 @@
 """Regression tests for rendering the Cookiecutter template."""
 
 import configparser
+import importlib
+import os
+import sys
 import tempfile
 import tomllib
 import unittest
 from pathlib import Path
 
+from cookiecutter.exceptions import FailedHookException
 from cookiecutter.main import cookiecutter
 
 
@@ -59,6 +63,76 @@ class TemplateRenderTest(unittest.TestCase):
                 workflow_text = workflow_path.read_text()
                 for unsupported in ("'3.8'", "'3.9'", "'3.10'", "'3.11'"):
                     self.assertNotIn(unsupported, workflow_text)
+
+
+class AppNameValidationTest(unittest.TestCase):
+    """Verify the pre-generation hook guards the app_name contract."""
+
+    def _reject(self, app_name: str) -> str:
+        """Render with app_name, assert it fails, and return the hook's output."""
+        template_dir = Path(__file__).resolve().parents[1]
+
+        with (
+            tempfile.TemporaryDirectory() as output_dir,
+            tempfile.TemporaryFile(mode="w+") as captured,
+        ):
+            sys.stderr.flush()
+            saved_stderr = os.dup(2)
+            os.dup2(captured.fileno(), 2)
+            try:
+                with self.assertRaises(FailedHookException):
+                    cookiecutter(
+                        str(template_dir),
+                        no_input=True,
+                        output_dir=output_dir,
+                        extra_context={"app_name": app_name},
+                    )
+            finally:
+                sys.stderr.flush()
+                os.dup2(saved_stderr, 2)
+                os.close(saved_stderr)
+
+            self.assertEqual(list(Path(output_dir).iterdir()), [])
+            captured.seek(0)
+            return captured.read()
+
+    def test_custom_identifier_renders_importable_package(self) -> None:
+        """Accept a custom identifier and import the package it generates."""
+        template_dir = Path(__file__).resolve().parents[1]
+        app_name = "custom_pkg"
+
+        with tempfile.TemporaryDirectory() as output_dir:
+            project_dir = Path(
+                cookiecutter(
+                    str(template_dir),
+                    no_input=True,
+                    output_dir=output_dir,
+                    extra_context={"app_name": app_name},
+                )
+            )
+            config = tomllib.loads((project_dir / "pyproject.toml").read_text())
+
+            self.assertEqual(config["project"]["name"], app_name)
+            sys.path.insert(0, str(project_dir))
+            importlib.invalidate_caches()
+            try:
+                package = importlib.import_module(app_name)
+                self.assertEqual(
+                    Path(package.__file__).parent, project_dir / app_name
+                )
+            finally:
+                sys.path.remove(str(project_dir))
+                sys.modules.pop(app_name, None)
+                importlib.invalidate_caches()
+
+    def test_invalid_app_names_fail_generation(self) -> None:
+        """Reject names that cannot be imported or published as written."""
+        for app_name in ("my-package", "my package", "123pkg", "class", "pürepy"):
+            with self.subTest(app_name=app_name):
+                message = self._reject(app_name)
+
+                self.assertIn(repr(app_name), message)
+                self.assertIn("valid Python identifier", message)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #18

## What changed

`app_name` is used as both the generated import package (`{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/`) and the distribution name in `pyproject.toml`, with nothing checking it. `my-package`, `my package`, `123pkg` and `class` all rendered successfully into a project that cannot be imported as the documented package.

- **`hooks/pre_gen_project.py`** (new): rejects any `app_name` that is not an ASCII Python identifier, or that is a Python keyword, with a message naming the offending value and the rule. Generation aborts before any files are left behind.
- **`tests/test_template.py`**: adds `AppNameValidationTest` — one valid custom name (`custom_pkg`) that renders and whose package is actually imported, and a subtest table of the invalid names, each asserting the failure, the message content, and that no output directory survives.

The hook interpolates the value with `| jsonify` rather than bare `{{ ... }}`, so a name containing a quote or backslash can't turn the rendered hook into a syntax error or an injection point — those names get the normal rejection message instead.

### Judgment call: ASCII

The issue asked for "valid Python identifier"; `str.isidentifier()` alone accepts non-ASCII names like `pürepy`, which import fine but produce a `pyproject.toml` that packaging tooling flatly rejects (`Not a valid package or extra name: "café"`). Since that is the same failure class the issue targets — renders clean, broken afterwards — the check requires ASCII too. Distribution-name flexibility (a separate `package_name` vs `project_slug`) stays out of scope as the issue specifies.

## Verification

All run in this worktree with `uv run --with cookiecutter python -m unittest discover -s tests` (the same command CI runs, so the new tests are exercised by the existing workflow).

- **Suite green:** 4 tests pass, including both pre-existing default-render tests.
- **The new tests are not vacuous** — mutation-tested per clause, then restored (`git diff` confirmed test-only + the new hook):
  - hook removed entirely → **5 subtest failures**, i.e. every one of the five invalid names renders successfully without it; none of the table rows is a freebie.
  - `keyword.iskeyword(...)` clause dropped → 1 failure (`class`).
  - `isascii()` clause dropped → 1 failure (`pürepy`).
  - hook mutated to reject everything → 3 errors, including the valid-name test, so it guards against over-rejection rather than just passing alongside.
- **Import check is real:** the valid-name test puts the generated project on `sys.path`, imports `custom_pkg`, and asserts the module resolves to `<project>/custom_pkg`.
- **End-to-end packaging:** rendered with `app_name=custom_pkg` and ran `uv build` in the result — `custom_pkg-0.0.1.tar.gz` and `custom_pkg-0.0.1-py3-none-any.whl` both built successfully.
- **Injection robustness:** rendering with `my"pkg`, `pkg\\` and `import os; x` each aborts with the normal `FailedHookException` and message — no `SyntaxError`, no execution.
